### PR TITLE
Use new arduino/setup-task action name in CI/CD workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Taskfile
-        uses: arduino/actions/setup-taskfile@master
+        uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x


### PR DESCRIPTION
The GitHub Actions action for installing [Task](https://taskfile.dev/#/) has graduated from its original home in [the experimental `arduino/action`repository](https://github.com/arduino/actions) with a move to a dedicated permanent repository at [`arduino/setup-task`](https://github.com/arduino/setup-task).

A [1.0.0 release](https://github.com/arduino/setup-task/releases/tag/v1.0.0) has been made and [a `v1` ref](https://github.com/arduino/setup-task/tree/v1) that will track all releases in the major version 1 series. Use of the action's major version ref will cause the workflow to benefit from ongoing development to the action at each [patch or minor release](https://semver.org/) up until such time as a new major release is made. At this time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref in the workflows (e.g., `uses: arduino/setup-task@v2`).