### PR TITLE
Add "v" prefix to changelog generation regex

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create changelog
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          tag-regex: '^v[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"


### PR DESCRIPTION
The workflow used as a reference for this repository's "Release" workflow was based on the style of tags used in the Arduino CLI repository, where the tag name is identical to the version name. The tags filter was updated to the "v"-prefixed tag name style used by this repository (and required by Go) but [the `arduino/create-changelog` action's `tag-regex` input](https://github.com/arduino/create-changelog#inputs) value was not. This resulted in the generated changelog containing the repository's entire commit history.