### PR TITLE
Update go-serial to version 1.3.5

### DIFF
--- a/.licenses/serial-discovery/go/go.bug.st/serial.dep.yml
+++ b/.licenses/serial-discovery/go/go.bug.st/serial.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: go.bug.st/serial
-version: v1.3.2
+version: v1.3.5
 type: go
 summary: Package serial is a cross-platform serial library for the go language.
 homepage: https://pkg.go.dev/go.bug.st/serial

--- a/.licenses/serial-discovery/go/go.bug.st/serial/enumerator.dep.yml
+++ b/.licenses/serial-discovery/go/go.bug.st/serial/enumerator.dep.yml
@@ -1,13 +1,13 @@
 ---
 name: go.bug.st/serial/enumerator
-version: v1.3.2
+version: v1.3.5
 type: go
 summary: Package enumerator is a golang cross-platform library for USB serial port
   discovery.
 homepage: https://pkg.go.dev/go.bug.st/serial/enumerator
 license: bsd-3-clause
 licenses:
-- sources: serial@v1.3.2/LICENSE
+- sources: serial@v1.3.5/LICENSE
   text: |2+
 
     Copyright (c) 2014-2021, Cristian Maglie.
@@ -42,7 +42,7 @@ licenses:
     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 
-- sources: serial@v1.3.2/README.md
+- sources: serial@v1.3.5/README.md
   text: |-
     The software is release under a [BSD 3-clause license]
 

--- a/.licenses/serial-discovery/go/go.bug.st/serial/unixutils.dep.yml
+++ b/.licenses/serial-discovery/go/go.bug.st/serial/unixutils.dep.yml
@@ -1,12 +1,12 @@
 ---
 name: go.bug.st/serial/unixutils
-version: v1.3.2
+version: v1.3.5
 type: go
 summary: 
 homepage: https://pkg.go.dev/go.bug.st/serial/unixutils
 license: bsd-3-clause
 licenses:
-- sources: serial@v1.3.2/LICENSE
+- sources: serial@v1.3.5/LICENSE
   text: |2+
 
     Copyright (c) 2014-2021, Cristian Maglie.
@@ -41,7 +41,7 @@ licenses:
     ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
     POSSIBILITY OF SUCH DAMAGE.
 
-- sources: serial@v1.3.2/README.md
+- sources: serial@v1.3.5/README.md
   text: |-
     The software is release under a [BSD 3-clause license]
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/arduino/go-properties-orderedmap v1.6.0
 	github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.0.2
 	github.com/s-urbaniak/uevent v1.0.1
-	go.bug.st/serial v1.3.2
+	go.bug.st/serial v1.3.5
 	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
 )
 

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,9 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 go.bug.st/cleanup v1.0.0/go.mod h1:EqVmTg2IBk4znLbPD28xne3abjsJftMdqqJEjhn70bk=
 go.bug.st/downloader/v2 v2.1.1/go.mod h1:VZW2V1iGKV8rJL2ZEGIDzzBeKowYv34AedJz13RzVII=
 go.bug.st/relaxed-semver v0.0.0-20190922224835-391e10178d18/go.mod h1:Cx1VqMtEhE9pIkEyUj3LVVVPkv89dgW8aCKrRPDR/uE=
-go.bug.st/serial v1.3.2 h1:6BFZZd/wngoL5PPYYTrFUounF54SIkykHpT98eq6zvk=
 go.bug.st/serial v1.3.2/go.mod h1:jDkjqASf/qSjmaOxHSHljwUQ6eHo/ZX/bxJLQqSlvZg=
+go.bug.st/serial v1.3.5 h1:k50SqGZCnHZ2MiBQgzccXWG+kd/XpOs1jUljpDDKzaE=
+go.bug.st/serial v1.3.5/go.mod h1:z8CesKorE90Qr/oRSJiEuvzYRKol9r/anJZEb5kt304=
 go.bug.st/serial.v1 v0.0.0-20180827123349-5f7892a7bb45/go.mod h1:dRSl/CVCTf56CkXgJMDOdSwNfo2g1orOGE/gBGdvjZw=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=
 go.etcd.io/etcd/client/pkg/v3 v3.5.0/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=


### PR DESCRIPTION
upstream fixes

* Fix wrong port enumeration for `/dev/ttySxx` in case of "permission denied" error: https://github.com/bugst/go-serial/pull/135