### PR TITLE
Update release workflows to add macOS arm64 support

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -1,8 +1,9 @@
 # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-tester-task.md
 name: Publish Tester Build
 
-# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
 on:
+  create:
   push:
     paths:
       - ".github/workflows/publish-go-tester-task.ya?ml"
@@ -23,19 +24,94 @@ on:
   repository_dispatch:
 
 env:
+  # As defined by the Taskfile's PROJECT_NAME variable
+  PROJECT_NAME: serial-discovery
   # As defined by the Taskfile's DIST_DIR variable
   DIST_DIR: dist
-  BUILDS_ARTIFACT: build-artifacts
 
 jobs:
-  build:
+  run-determination:
     runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/v[0-9]+.[0-9]+.x"
+          TAG_REGEX="refs/tags/.*"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            ("${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) &&
+            ! "${{ github.ref }}" =~ $TAG_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  package-name-prefix:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      prefix: ${{ steps.calculation.outputs.prefix }}
+    steps:
+      - name: package name prefix calculation
+        id: calculation
+        run: |
+          PACKAGE_NAME_PREFIX="test"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
+          fi
+          PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
+
+          echo "prefix=$PACKAGE_NAME_PREFIX" >> $GITHUB_OUTPUT
+
+  build:
+    needs: package-name-prefix
+    name: Build ${{ matrix.os.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os:
+          - task: Windows_32bit
+            path: "*Windows_32bit.zip"
+            name: Windows_X86-32
+          - task: Windows_64bit
+            path: "*Windows_64bit.zip"
+            name: Windows_X86-64
+          - task: Linux_32bit
+            path: "*Linux_32bit.tar.gz"
+            name: Linux_X86-32
+          - task: Linux_64bit
+            path: "*Linux_64bit.tar.gz"
+            name: Linux_X86-64
+          - task: Linux_ARMv6
+            path: "*Linux_ARMv6.tar.gz"
+            name: Linux_ARMv6
+          - task: Linux_ARMv7
+            path: "*Linux_ARMv7.tar.gz"
+            name: Linux_ARMv7
+          - task: Linux_ARM64
+            path: "*Linux_ARM64.tar.gz"
+            name: Linux_ARM64
+          - task: macOS_64bit
+            path: "*macOS_64bit.tar.gz"
+            name: macOS_64
+          - task: macOS_ARM64
+            path: "*macOS_ARM64.tar.gz"
+            name: macOS_ARM64
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Install Task
         uses: arduino/setup-task@v1
@@ -45,67 +121,41 @@ jobs:
 
       - name: Build
         run: |
-          PACKAGE_NAME_PREFIX="test"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
-          fi
-          PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
+          PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}
           export PACKAGE_NAME_PREFIX
-          task dist:all
+          task dist:${{ matrix.os.task }}
 
       # Transfer builds to artifacts job
-      - name: Upload combined builds artifact
+      - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.DIST_DIR }}
-          name: ${{ env.BUILDS_ARTIFACT }}
+          path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
+          name: ${{ matrix.os.name }}
 
-  artifacts:
-    name: ${{ matrix.artifact.name }} artifact
-    needs: build
+  checksums:
+    needs:
+      - build
+      - package-name-prefix
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        artifact:
-          - path: "*checksums.txt"
-            name: checksums
-          - path: "*Linux_32bit.tar.gz"
-            name: Linux_X86-32
-          - path: "*Linux_64bit.tar.gz"
-            name: Linux_X86-64
-          - path: "*Linux_ARM64.tar.gz"
-            name: Linux_ARM64
-          - path: "*Linux_ARMv6.tar.gz"
-            name: Linux_ARMv6
-          - path: "*Linux_ARMv7.tar.gz"
-            name: Linux_ARMv7
-          - path: "*macOS_64bit.tar.gz"
-            name: macOS_64
-          - path: "*Windows_32bit.zip"
-            name: Windows_X86-32
-          - path: "*Windows_64bit.zip"
-            name: Windows_X86-64
-
     steps:
-      - name: Download combined builds artifact
+      - name: Download build artifacts
         uses: actions/download-artifact@v3
-        with:
-          name: ${{ env.BUILDS_ARTIFACT }}
-          path: ${{ env.BUILDS_ARTIFACT }}
 
-      - name: Upload individual build artifact
+      - name: Create checksum file
+        run: |
+          TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
+          declare -a artifacts=($(ls -d */))
+          for artifact in ${artifacts[@]}
+          do
+            cd $artifact
+            checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
+            cd ..
+            echo $checksum >> ${TAG}-checksums.txt
+          done
+
+      - name: Upload checksum artifact
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.BUILDS_ARTIFACT }}/${{ matrix.artifact.path }}
-          name: ${{ matrix.artifact.name }}
-
-  clean:
-    needs: artifacts
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Remove unneeded combined builds artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: ${{ env.BUILDS_ARTIFACT }}
+          path: ./*checksums.txt
+          name: checksums

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -19,6 +19,19 @@ jobs:
   create-release-artifacts:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        os:
+          - Windows_32bit
+          - Windows_64bit
+          - Linux_32bit
+          - Linux_64bit
+          - Linux_ARMv6
+          - Linux_ARMv7
+          - Linux_ARM64
+          - macOS_64bit
+          - macOS_ARM64
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -26,6 +39,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create changelog
+        # Avoid creating the same changelog for each os
+        if: matrix.os == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^v[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -40,16 +55,47 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:all
+        run: task dist:${{ matrix.os }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: create-release-artifacts
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.DIST_DIR }}
+
+      - name: Create checksum file
+        working-directory: ${{ env.DIST_DIR}}
+        run: |
+          TAG="${GITHUB_REF/refs\/tags\//}"
+          sha256sum ${{ env.PROJECT_NAME }}_${TAG}* > ${TAG}-checksums.txt
 
       - name: Identify Prerelease
         # This is a workaround while waiting for create-release action
         # to implement auto pre-release based on tag
         id: prerelease
         run: |
-          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.0.0.zip
-          unzip -p /tmp/3.0.0.zip semver-tool-3.0.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[ "$(/tmp/semver get prerel "${GITHUB_REF/refs\/tags\//}")" ]]; then echo "::set-output name=IS_PRE::true"; fi
+          wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
+          unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
+          if [[
+            "$(
+              /tmp/semver get prerel \
+                "${GITHUB_REF/refs\/tags\//}"
+            )"
+          ]]; then
+            echo "IS_PRE=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Github Release and upload artifacts
         uses: ncipollo/release-action@v1

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -20,36 +20,20 @@ version: "3"
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
   GO_VERSION: "1.16.4"
-  CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:
-  all:
-    desc: Build for distribution for all platforms
-    cmds:
-      - task: Windows_32bit
-      - task: Windows_64bit
-      - task: Linux_32bit
-      - task: Linux_64bit
-      - task: Linux_ARMv6
-      - task: Linux_ARMv7
-      - task: Linux_ARM64
-      - task: macOS_64bit
-
   Windows_32bit:
     desc: Builds Windows 32 bit binaries
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -64,16 +48,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -88,16 +69,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -112,16 +90,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -136,16 +111,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -160,16 +132,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -212,16 +181,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
@@ -236,16 +202,13 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-        sha256sum {{.PACKAGE_NAME}} >> {{.CHECKSUM_FILE}}
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -266,4 +229,25 @@ tasks:
       # has the SDK 10.14 installed.
       CONTAINER_TAG: "{{.GO_VERSION}}-darwin-debian10"
       PACKAGE_PLATFORM: "macOS_64bit"
+      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
+
+  macOS_ARM64:
+    desc: Builds Mac OS X ARM64 binaries
+    dir: "{{.DIST_DIR}}"
+    cmds:
+      - |
+        docker run -v `pwd`/..:/home/build -w /home/build \
+        -e CGO_ENABLED=1 \
+        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
+        --build-cmd "{{.BUILD_COMMAND}}" \
+        -p "{{.BUILD_PLATFORM}}"
+
+        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+
+    vars:
+      PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
+      BUILD_COMMAND: "go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}"
+      BUILD_PLATFORM: "darwin/arm64"
+      CONTAINER_TAG: "{{.GO_VERSION}}-darwin-arm64-debian10"
+      PACKAGE_PLATFORM: "macOS_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"


### PR DESCRIPTION
`release-go-task` and `publish-go-tester-task` have been updated to match their [upstream](https://github.com/arduino/tooling-project-assets/tree/main/workflow-templates) counterpart and to add release support for macOS arm64.

Since previous releases have a tag like `v1.3.3`, I modified `RELEASE_BRANCH_REGEX` in the `run-determination` job inside `publish-go-tester-task` to include the `v`. For the same reason, I left the `on.push.tags` trigger of `release-go-task` unchanged and did not mirror the upstream trigger.