### PR TITLE
Create archive with upper level directory

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -27,13 +27,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -48,13 +50,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -69,13 +73,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -90,13 +96,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -111,13 +119,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -132,13 +142,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -181,13 +193,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
@@ -202,13 +216,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -236,13 +252,15 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
         docker run -v `pwd`/..:/home/build -w /home/build \
         -e CGO_ENABLED=1 \
         {{.CONTAINER}}:{{.CONTAINER_TAG}} \
         --build-cmd "{{.BUILD_COMMAND}}" \
         -p "{{.BUILD_PLATFORM}}"
 
-        tar cz -C {{.PLATFORM_DIR}} {{.PROJECT_NAME}} -C ../.. LICENSE.txt  -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"


### PR DESCRIPTION
The release archives used to have an upper level directory which contained the executable and the license. The directory's creation process was removed by accident in PR #57, so those changes need to be reverted.