### PR TITLE
Use native Linux ARM runners for ARM 64-bit builds

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -78,7 +78,7 @@ jobs:
   build:
     needs: package-name-prefix
     name: Build ${{ matrix.os.artifact-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -88,33 +88,43 @@ jobs:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
             artifact-name: Windows_X86-32
+            runner: ubuntu-latest
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
             artifact-name: Windows_X86-64
+            runner: ubuntu-latest
           - task: Windows_ARM64
             path: "*Windows_ARM64.zip"
             artifact-name: Windows_ARM64
+            runner: ubuntu-24.04-arm
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
             artifact-name: Linux_X86-32
+            runner: ubuntu-latest
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
             artifact-name: Linux_X86-64
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
             artifact-name: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
             artifact-name: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
             artifact-name: Linux_ARM64
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
             artifact-name: macOS_64
+            runner: ubuntu-latest
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
             artifact-name: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
@@ -125,9 +135,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Build
         run: |

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   create-release-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os.runner }}
     permissions:
       contents: read
 
@@ -27,24 +27,34 @@ jobs:
         os:
           - task: Windows_32bit
             artifact-suffix: Windows_32bit
+            runner: ubuntu-latest
           - task: Windows_64bit
             artifact-suffix: Windows_64bit
+            runner: ubuntu-latest
           - task: Windows_ARM64
             artifact-suffix: Windows_ARM64
+            runner: ubuntu-24.04-arm
           - task: Linux_32bit
             artifact-suffix: Linux_32bit
+            runner: ubuntu-latest
           - task: Linux_64bit
             artifact-suffix: Linux_64bit
+            runner: ubuntu-latest
           - task: Linux_ARMv6
             artifact-suffix: Linux_ARMv6
+            runner: ubuntu-latest
           - task: Linux_ARMv7
             artifact-suffix: Linux_ARMv7
+            runner: ubuntu-latest
           - task: Linux_ARM64
             artifact-suffix: Linux_ARM64
+            runner: ubuntu-24.04-arm
           - task: macOS_64bit
             artifact-suffix: macOS_64bit
+            runner: ubuntu-latest
           - task: macOS_ARM64
             artifact-suffix: macOS_ARM64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout repository
@@ -67,9 +77,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Build
         run: task dist:${{ matrix.os.task }}


### PR DESCRIPTION
The build workflows generate ARM 64-bit builds of the application for Linux, macOS, and Windows hosts. When those builds are performed in the x86 "ubuntu-latest" runner machine, they fail due to incompatibility between the Docker container in which the builds are performed and the runner architecture:

```text
Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.25.2-windows-arm64-debian12
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
exec /crossbuild: exec format error
task: Failed to run task "dist:Windows_ARM64": exit status 255
```

The established solution (https://github.com/arduino/arduino-cli/pull/2850, https://github.com/arduino/arduino-cli/pull/2896, https://github.com/arduino/arduino-cli/pull/3007, https://github.com/arduino/arduino-lint/pull/952) for this problem is to instead use the Linux ARM "ubuntu-24.04-arm" runner machine for those
builds:

- https://github.com/arduino/arduino-cli/blob/7b8b2159b2964d961ea0d9f9a8ceb1523f0853c4/.github/workflows/publish-go-nightly-task.yml#L31-L55
- https://github.com/arduino/arduino-cli/blob/7b8b2159b2964d961ea0d9f9a8ceb1523f0853c4/.github/workflows/publish-go-tester-task.yml#L79-L127
- https://github.com/arduino/arduino-cli/blob/7b8b2159b2964d961ea0d9f9a8ceb1523f0853c4/.github/workflows/release-go-task.yml#L23-L45
- https://github.com/arduino/arduino-lint/blob/971bea8ffa9622870069376f855b423c2e31f6d1/.github/workflows/publish-go-nightly-task.yml#L24-L60
- https://github.com/arduino/arduino-lint/blob/971bea8ffa9622870069376f855b423c2e31f6d1/.github/workflows/publish-go-tester-task.yml#L81-L127
- https://github.com/arduino/arduino-lint/blob/971bea8ffa9622870069376f855b423c2e31f6d1/.github/workflows/release-go-task.yml#L21-L57


The builds can be performed on this runner due to it having the required host architecture for compatibility
with the build containers.

Previously (https://github.com/arduino/serial-discovery/pull/93), an alternative solution was used in this project: using [**QEMU**](https://github.com/qemu/qemu) to emulate the required host architecture. That
solution was inferior in multiple ways:

- Introduces an additional action dependency ([**docker/setup-qemu-action**](https://github.com/docker/setup-qemu-action)).
- Less efficient due to the overhead of installing QEMU, and the inferior performance of the build under emulation.

Regarding the latter, here are the durations of the build job of the "Publish Tester Build" workflow, for the QEMU based approach implemented by https://github.com/arduino/serial-discovery/pull/93 and the native approach proposed by this pull request:

| Build          | `main` (s) | PR (s) |
| -------------- | -------- | ------ |
| Linux_ARM64    | 129.5    | 41.5   |
| Linux_ARMv6    | 47.5     | 44.5   |
| Linux_ARMv7    | 49.5     | 38.5   |
| Linux_X86-32   | 50.5     | 41.5   |
| Linux_X86-64   | 55       | 41.5   |
| macOS_64       | 57       | 54.5   |
| macOS_ARM64    | 181      | 80.5   |
| Windows_ARM64  | 159.5    | 73.5   |
| Windows_X86-32 | 51.5     | 50.5   |
| Windows_X86-64 | 54.5     | 44     |

The durations are the averaged of two separate runs of each workflow, interleaved. This was done to reduce the possible influence of transient conditions on the results. The deviation between runs of each variant of the workflow was not significant.

For this reason, it is here proposed that the workflow be ported to using the appropriate runner machine for the ARM 64-bit build jobs instead of depending on QEMU.

### Additional context

It is standard practice to use the "latest" GitHub Actions runner identifiers in the project's workflows, which causes the workflow runs to always use the newest stable runner version. However, GitHub has broken from this established convention by choosing to not provide "latest" identifiers for the Linux ARM runners (https://github.com/actions/partner-runner-images/issues/118#issuecomment-3151859667). For this reason, the version-specific runner name was used in the workflow. It will be necessary to manually update the runner name as new stable versions are made available (or more likely fail to do so until forced after GitHub's removal of the runner in use breaks the workflows).
