### PR TITLE
Fixed distribution archive format.

### DIFF
--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -28,6 +28,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -35,11 +37,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
@@ -54,6 +52,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -61,11 +61,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_amd64"
@@ -80,6 +76,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -87,11 +85,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        zip \
-          {{.PACKAGE_NAME}} \
-          {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe ../LICENSE.txt \
-          -j
+        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}} -r
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_arm64"
@@ -106,6 +100,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -113,13 +109,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
@@ -134,6 +124,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -141,13 +133,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "{{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd64"
@@ -162,6 +148,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -169,13 +157,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
@@ -190,6 +172,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -197,13 +181,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
@@ -218,6 +196,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -225,13 +205,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
@@ -246,6 +220,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -253,13 +229,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_amd64"
@@ -287,6 +257,8 @@ tasks:
     dir: "{{.DIST_DIR}}"
     cmds:
       - |
+        mkdir -p {{.PLATFORM_DIR}}
+        cp ../LICENSE.txt {{.PLATFORM_DIR}}
         docker run \
           -v `pwd`/..:/home/build \
           -w /home/build \
@@ -294,13 +266,7 @@ tasks:
           {{.CONTAINER}}:{{.CONTAINER_TAG}} \
           --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
           -p "{{.BUILD_PLATFORM}}"
-
-        tar cz \
-          -C {{.PLATFORM_DIR}} \
-          {{.PROJECT_NAME}} \
-          -C ../.. \
-          LICENSE.txt \
-          -f {{.PACKAGE_NAME}}
+        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
 
     vars:
       PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"


### PR DESCRIPTION
Previously, the zip archives were created without a root folder. This PR fixes this issue.
This is actually a regression after #93, which removed the DistTask section:

```patch
-mkdir -p {{.PLATFORM_DIR}}
-cp ../LICENSE.txt {{.PLATFORM_DIR}}
 docker run ...
```

You must run the `mkdir` command before starting Docker to ensure write permission on the `PLATFORM_DIR` directory; otherwise, the directory will be created by the `go build` command inside the Docker container, which runs as root, making it impossible to copy the LICENSE file later.

We might want to push this change upstream in the assets repo. /cc @per1234 