### PR TITLE
Add FreeBSD START_SYNC implementation

### DIFF
--- a/sync/sync_bsd.go
+++ b/sync/sync_bsd.go
@@ -17,10 +17,6 @@
 
 //go:build darwin || freebsd
 
-//
-// This file is part of serial-discovery.
-//
-
 package sync
 
 import (

--- a/sync/sync_bsd.go
+++ b/sync/sync_bsd.go
@@ -15,6 +15,12 @@
 // a commercial license, send an email to license@arduino.cc.
 //
 
+//go:build darwin || freebsd
+
+//
+// This file is part of serial-discovery.
+//
+
 package sync
 
 import (

--- a/sync/sync_default.go
+++ b/sync/sync_default.go
@@ -15,7 +15,7 @@
 // a commercial license, send an email to license@arduino.cc.
 //
 
-//go:build !linux && !windows && !darwin
+//go:build !linux && !windows && !darwin && !freebsd
 
 package sync
 


### PR DESCRIPTION
This PR enables START_SYNC support on FreeBSD by reusing the existing BSD kqueue implementation.

Instead of maintaining separate implementations for Darwin and FreeBSD, the existing sync_darwin.go has been generalized to sync_bsd.go and shared between both platforms. The fallback implementation in sync_default.go has also been updated so FreeBSD now uses the BSD implementation.

The changes were validated by successfully building the project, running the test suite, and verifying START_SYNC functionality on FreeBSD.